### PR TITLE
фикс бага с warning при установке аттрибутов группировки

### DIFF
--- a/lib/traits/elements.php
+++ b/lib/traits/elements.php
@@ -548,7 +548,7 @@ trait Elements
     {
         if (is_array($fields) && !empty($fields))
         {
-            $this->groupingParams = array_merge($this->groupingParams, $fields);
+            $this->groupingParams = array_merge(is_array($this->groupingParams) ? $this->groupingParams : [], $fields);
         }
     }
 


### PR DESCRIPTION
это может очень сильно изменить результаты выборки. там где раньше не группировалось, может сгруппироваться
