### PR TITLE
Корректировка работы с постраничной навигацией

### DIFF
--- a/lib/traits/elements.php
+++ b/lib/traits/elements.php
@@ -97,7 +97,7 @@ trait Elements
                 $navComponentObject,
                 $this->arParams['PAGER_TITLE'],
                 $this->arParams['PAGER_TEMPLATE'],
-                 ($this->arParams['PAGER_SHOW_ALWAYS']=='Y'?true:false)
+                ($this->arParams['PAGER_SHOW_ALWAYS'] === 'Y' ? true : false)
             );
             $this->arResult['NAV_CACHED_DATA'] = $navComponentObject->GetTemplateCachedData();
             $this->arResult['NAV_RESULT'] = $result;

--- a/lib/traits/elements.php
+++ b/lib/traits/elements.php
@@ -97,7 +97,7 @@ trait Elements
                 $navComponentObject,
                 $this->arParams['PAGER_TITLE'],
                 $this->arParams['PAGER_TEMPLATE'],
-                $this->arParams['PAGER_SHOW_ALWAYS']
+                 ($this->arParams['PAGER_SHOW_ALWAYS']=='Y'?true:false)
             );
             $this->arResult['NAV_CACHED_DATA'] = $navComponentObject->GetTemplateCachedData();
             $this->arResult['NAV_RESULT'] = $result;


### PR DESCRIPTION
В GetPageNavStringEx используется не Y/N, а true/false